### PR TITLE
Single stock page

### DIFF
--- a/client/src/scenes/Login.jsx
+++ b/client/src/scenes/Login.jsx
@@ -206,62 +206,7 @@ export default function Login(props) {
                 </Button>
               </Box>
             </Box>
-          ) : (
-            <Box
-              className='container'
-              sx={{
-                display: 'flex',
-                flexDirection: 'column',
-                backgroundColor: 'gainsboro',
-                margin: 'auto',
-                width: '80%',
-                height: '400px',
-                borderRadius: '10px',
-                alignItems: 'center',
-                justifyContent: 'center',
-              }}
-            >
-              <Typography
-                variant='h1'
-                gutterBottom
-                sx={{ fontSize: 'xx-large', fontWeight: 'bold' }}
-              >
-                Sign In
-              </Typography>
-              <Typography variant='h2' gutterBottom sx={{ fontSize: 'medium', fontWeight: 'bold' }}>
-                Don't Have An Account?{' '}
-                <a href='#' onClick={SetToRegister}>
-                  Register
-                </a>
-              </Typography>
-              <TextField
-                required
-                id='outlined-basic'
-                label='Username'
-                variant='outlined'
-                sx={{ width: '75%', marginBottom: '15px' }}
-                value={username}
-                onChange={UpdateUsername}
-              />
-              <TextField
-                required
-                id='outlined-password-input'
-                label='Password'
-                type='password'
-                sx={{ width: '75%' }}
-                value={pass}
-                onChange={UpdatePassword}
-              />
-              <Button
-                sx={{ marginTop: '50px', marginRight: '60%' }}
-                variant='contained'
-                onClick={SubmitLogin}
-              >
-                Submit
-              </Button>
-            </Box>
-          </Box>
-        ) : (
+          ) : (            
           <Box
             className='container'
             sx={{


### PR DESCRIPTION
Update: This PR only contains a fix for main that is currently down. I must have accidently checked in my branch when trying to update my main and resolve merge conflicts.

This PR removes an old Box element that was essentially duplicated and caused main to break. merging this PR will bring main back up.

// comments below were for the changes I accidently already merged into main
Stock page (Stock.jsx)
- This page will be used to display information on a single stock to the user. it has been setup to use the Alpha vantage API however the keys are currently set to demo rather than my keys for now. This page uses a useEffect to call the api and grab overview data for the stock information tab and uses a ternary to guarantee loaded content once the data is ready and has come back from the api.

Chart component:
- this component is used to create the line chart for the stocks most recent high and low data. This has also been setup to grab data from the api and will only load when the data is ready. passed to this component should be stock ticker, range of days to show and the name of the stock.

WAVE is passed except for one warning not related to my changes but that I will address in future changes. also included in this request are various code cleanups and removal of unneeded code 